### PR TITLE
Autonomous Apple Music sync for "On Repeat"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4766,6 +4766,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7514,6 +7523,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.1",
+        "jose": "^5.10.0",
         "mongodb": "^6.10.0",
         "ws": "^8.18.0"
       }

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,23 @@
+# ---------------------------------------------------------------------------
+# Core
+# ---------------------------------------------------------------------------
+MONGODB_URI=your_mongodb_connection_string
+HOST=localhost
+PORT=3000
+
+# ---------------------------------------------------------------------------
+# Apple Music (autonomous server-side "On Repeat" — replaces the iOS app)
+# ---------------------------------------------------------------------------
+# From the Apple Developer portal (Membership page):
+APPLE_TEAM_ID=ABCDE12345
+
+# From Certificates, Identifiers & Profiles -> Keys -> your MusicKit key:
+APPLE_MUSIC_KEY_ID=ABCDE12345
+
+# Contents of the downloaded MusicKit .p8 key. Either paste the PEM directly
+# (Railway supports multiline values) or base64-encode the whole file:
+#   base64 -i AuthKey_XXXX.p8 | pbcopy
+APPLE_MUSIC_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----
+
+# Captured ONCE via /apple-auth (sign in with your Apple Music account):
+APPLE_MUSIC_USER_TOKEN=your_music_user_token

--- a/server/apple-auth.html
+++ b/server/apple-auth.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Apple Music — Capture User Token</title>
+    <style>
+      :root { color-scheme: dark; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0b0b0b;
+        color: #f5f5f5;
+        max-width: 640px;
+        margin: 6vh auto;
+        padding: 0 24px;
+        line-height: 1.5;
+      }
+      h1 { font-size: 1.5rem; }
+      button {
+        font-size: 1rem;
+        padding: 12px 20px;
+        border: 0;
+        border-radius: 10px;
+        background: #fa2d48;
+        color: #fff;
+        cursor: pointer;
+      }
+      button:disabled { opacity: 0.5; cursor: default; }
+      pre {
+        background: #161616;
+        border: 1px solid #2a2a2a;
+        border-radius: 10px;
+        padding: 16px;
+        white-space: pre-wrap;
+        word-break: break-all;
+        user-select: all;
+      }
+      .muted { color: #9a9a9a; font-size: 0.9rem; }
+      ol { padding-left: 1.2rem; }
+    </style>
+    <script
+      src="https://js-cdn.music.apple.com/musickit/v3/musickit.js"
+      data-web-components
+      async
+    ></script>
+  </head>
+  <body>
+    <h1>Capture your Apple Music User Token</h1>
+    <p class="muted">
+      Run this once (and again only if the token is ever revoked). Sign in with
+      the Apple ID whose listening history should power the site, copy the token
+      below, and set it as <code>APPLE_MUSIC_USER_TOKEN</code> in Railway.
+    </p>
+
+    <p>
+      <button id="authorize" disabled>Loading MusicKit…</button>
+    </p>
+
+    <pre id="out" hidden></pre>
+    <p id="error" class="muted"></p>
+
+    <script>
+      const btn = document.getElementById("authorize");
+      const out = document.getElementById("out");
+      const errEl = document.getElementById("error");
+
+      function showError(msg) {
+        errEl.textContent = msg;
+      }
+
+      document.addEventListener("musickitloaded", async () => {
+        try {
+          const res = await fetch("/api/apple-music/dev-token");
+          if (!res.ok) throw new Error("dev-token endpoint returned " + res.status);
+          const { token } = await res.json();
+          await MusicKit.configure({
+            developerToken: token,
+            app: { name: "vmello.dev", build: "1.0.0" },
+          });
+          btn.disabled = false;
+          btn.textContent = "Authorize Apple Music";
+        } catch (e) {
+          showError("Could not configure MusicKit: " + e.message);
+        }
+      });
+
+      btn.addEventListener("click", async () => {
+        try {
+          btn.disabled = true;
+          const music = MusicKit.getInstance();
+          const userToken = await music.authorize();
+          out.hidden = false;
+          out.textContent = "APPLE_MUSIC_USER_TOKEN=" + userToken;
+        } catch (e) {
+          showError("Authorization failed: " + e.message);
+          btn.disabled = false;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/server/appleMusic.js
+++ b/server/appleMusic.js
@@ -1,0 +1,203 @@
+/**
+ * Apple Music Server-Side Integration
+ * -----------------------------------
+ * Replaces the on-device `nvmMusic` iOS app with an autonomous, server-side
+ * poll of the Apple Music API — the same way the old Spotify integration worked.
+ *
+ * Two credentials are required:
+ *   1. Developer Token  — a short-lived ES256 JWT this server signs itself using
+ *      a MusicKit private key (.p8) from the Apple Developer portal.
+ *   2. Music User Token  — captured ONCE by the account owner via MusicKit JS
+ *      (see /apple-auth) and stored as an env var. Lets the server read YOUR
+ *      personal listening history.
+ *
+ * Required environment variables:
+ *   APPLE_TEAM_ID             10-char Apple Developer Team ID
+ *   APPLE_MUSIC_KEY_ID        10-char MusicKit Key ID (the .p8 you downloaded)
+ *   APPLE_MUSIC_PRIVATE_KEY   contents of the .p8 (PEM, with real or \n newlines,
+ *                             OR base64 of the whole file)
+ *   APPLE_MUSIC_USER_TOKEN    Music User Token from /apple-auth
+ */
+
+import { SignJWT, importPKCS8 } from "jose";
+
+const API_BASE = "https://api.music.apple.com";
+
+// NOTE: env vars are read lazily inside functions (not as module-level consts)
+// so this module is immune to import-vs-dotenv ordering — `import` statements
+// are hoisted above `dotenv.config()`, so reading at import time would see
+// undefined when credentials come from a local .env file.
+
+// Developer tokens are valid up to 6 months. We mint for 150 days and cache.
+const DEV_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 150;
+// Re-mint when fewer than this many seconds remain.
+const DEV_TOKEN_REFRESH_MARGIN = 60 * 60;
+
+let cachedPrivateKey = null;
+let cachedDevToken = null; // { token, exp }
+let cachedStorefront = null; // e.g. "us"
+
+/** True if all credentials needed to talk to Apple are present. */
+export function isAppleMusicConfigured() {
+  return Boolean(
+    process.env.APPLE_TEAM_ID &&
+      process.env.APPLE_MUSIC_KEY_ID &&
+      process.env.APPLE_MUSIC_PRIVATE_KEY &&
+      process.env.APPLE_MUSIC_USER_TOKEN
+  );
+}
+
+/**
+ * Normalizes the private key env var into PEM. Accepts:
+ *  - PEM with literal newlines
+ *  - PEM with escaped "\n" (common when pasted into a single-line env var)
+ *  - base64 of the raw .p8 file
+ */
+function decodePrivateKeyPem(raw) {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed.includes("BEGIN PRIVATE KEY")) {
+    return trimmed.replace(/\\n/g, "\n");
+  }
+  return Buffer.from(trimmed, "base64").toString("utf8");
+}
+
+async function getPrivateKey() {
+  if (cachedPrivateKey) return cachedPrivateKey;
+  const pem = decodePrivateKeyPem(process.env.APPLE_MUSIC_PRIVATE_KEY);
+  if (!pem) throw new Error("APPLE_MUSIC_PRIVATE_KEY is not set");
+  cachedPrivateKey = await importPKCS8(pem, "ES256");
+  return cachedPrivateKey;
+}
+
+/**
+ * Returns a cached developer token, minting a new one when missing or expiring.
+ * Safe to expose to the browser (MusicKit JS needs it) — it is NOT the private
+ * key and grants no access to a user's library on its own.
+ */
+export async function getDeveloperToken() {
+  const teamId = process.env.APPLE_TEAM_ID;
+  const keyId = process.env.APPLE_MUSIC_KEY_ID;
+  const now = Math.floor(Date.now() / 1000);
+  if (cachedDevToken && cachedDevToken.exp - now > DEV_TOKEN_REFRESH_MARGIN) {
+    return cachedDevToken.token;
+  }
+  if (!teamId || !keyId) {
+    throw new Error("Missing APPLE_TEAM_ID or APPLE_MUSIC_KEY_ID");
+  }
+
+  const key = await getPrivateKey();
+  const exp = now + DEV_TOKEN_TTL_SECONDS;
+  const token = await new SignJWT({})
+    .setProtectedHeader({ alg: "ES256", kid: keyId })
+    .setIssuer(teamId)
+    .setIssuedAt(now)
+    .setExpirationTime(exp)
+    .sign(key);
+
+  cachedDevToken = { token, exp };
+  console.log("🍎 Minted new Apple Music developer token");
+  return token;
+}
+
+/** Authenticated GET against the Apple Music API as the configured user. */
+async function appleGet(path) {
+  const userToken = process.env.APPLE_MUSIC_USER_TOKEN;
+  if (!userToken) throw new Error("APPLE_MUSIC_USER_TOKEN is not set");
+  const devToken = await getDeveloperToken();
+
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      Authorization: `Bearer ${devToken}`,
+      "Music-User-Token": userToken,
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Apple Music API ${res.status}: ${body.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+/** Expands an Apple artwork URL template ({w}/{h}) to a concrete size. */
+function artworkUrl(artwork, size = 300) {
+  if (!artwork?.url) return null;
+  return artwork.url.replace("{w}", String(size)).replace("{h}", String(size));
+}
+
+/** The user's Apple Music storefront (e.g. "us"), cached. Defaults to "us". */
+async function getStorefront() {
+  if (cachedStorefront) return cachedStorefront;
+  try {
+    const json = await appleGet("/v1/me/storefront");
+    cachedStorefront = json?.data?.[0]?.id || "us";
+  } catch {
+    cachedStorefront = "us";
+  }
+  return cachedStorefront;
+}
+
+/**
+ * Resolves a catalog artist ID by name via search. Used when the recently-played
+ * response omits the artists relationship, so the UI can deep-link to the artist
+ * page instead of a search. Returns null on miss (UI falls back to search).
+ */
+export async function resolveArtistId(name) {
+  if (!name) return null;
+  try {
+    const storefront = await getStorefront();
+    const json = await appleGet(
+      `/v1/catalog/${storefront}/search?term=${encodeURIComponent(
+        name
+      )}&types=artists&limit=1`
+    );
+    return json?.results?.artists?.data?.[0]?.id || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetches the most recently played tracks across all of this account's devices.
+ * Returns raw Apple `data` items (Song resources). No phone app required —
+ * Apple updates this as you listen on any device.
+ */
+export async function getRecentTracks(limit = 30) {
+  const json = await appleGet(
+    `/v1/me/recent/played/tracks?limit=${limit}&include=artists`
+  );
+  return Array.isArray(json?.data) ? json.data : [];
+}
+
+/**
+ * Maps an Apple Music recently-played Song item into a `listening_history`
+ * record for persistence. `playedAt` is the approximate play time (poll time —
+ * Apple gives no per-play timestamp). The `id` is unique per play event so a
+ * track played again later is stored as a distinct row.
+ */
+export function appleTrackToRecord(item, playedAt) {
+  const attrs = item?.attributes || {};
+  const songId = item?.id || null;
+  const relArtistId = item?.relationships?.artists?.data?.[0]?.id || null;
+  return {
+    id: `${songId}-${playedAt.getTime()}`,
+    timestamp: playedAt,
+    track_name: attrs.name || "Unknown Track",
+    artist_name: attrs.artistName || "Unknown Artist",
+    album_name: attrs.albumName || "Unknown Album",
+    ms_played:
+      typeof attrs.durationInMillis === "number" ? attrs.durationInMillis : 0,
+    platform: "server",
+    source: "apple_music",
+    apple_music_id: songId,
+    apple_music_artist_id: relArtistId,
+    spotify_uri: null,
+    album_artwork_url: artworkUrl(attrs.artwork),
+    genre: Array.isArray(attrs.genreNames) ? attrs.genreNames[0] || null : null,
+    release_date: attrs.releaseDate || null,
+    isrc: attrs.isrc || null,
+    content_rating: attrs.contentRating || null,
+    metadata: { polled: true },
+  };
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "@vmello/server",
   "private": true,
@@ -12,6 +11,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
+    "jose": "^5.10.0",
     "mongodb": "^6.10.0",
     "ws": "^8.18.0"
   }

--- a/server/scripts/captureAppleUserToken.js
+++ b/server/scripts/captureAppleUserToken.js
@@ -1,0 +1,73 @@
+/**
+ * Local Apple Music User Token Capture
+ * ------------------------------------
+ * A throwaway, localhost-only helper to capture a Music User Token via MusicKit
+ * JS without needing the full app/Mongo running.
+ *
+ *   node scripts/captureAppleUserToken.js   (run from the server/ directory)
+ *
+ * Then open http://localhost:4317/ , click Authorize, sign in to Apple Music.
+ * The token is written to server/.env (APPLE_MUSIC_USER_TOKEN) and shown on the
+ * page so you can also paste it into Railway.
+ *
+ * Binds to 127.0.0.1 only — it is a local dev tool, not part of the deployed app.
+ */
+
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import express from "express";
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { getDeveloperToken } from "../appleMusic.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ENV_PATH = join(__dirname, "..", ".env");
+const PORT = 4317;
+
+const app = express();
+app.use(express.json());
+
+app.get("/api/apple-music/dev-token", async (req, res) => {
+  try {
+    res.json({ token: await getDeveloperToken() });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+/** Upsert APPLE_MUSIC_USER_TOKEN into server/.env */
+app.post("/save", (req, res) => {
+  const token = req.body?.token;
+  if (!token || typeof token !== "string") {
+    return res.status(400).json({ error: "missing token" });
+  }
+  let env = existsSync(ENV_PATH) ? readFileSync(ENV_PATH, "utf8") : "";
+  const line = `APPLE_MUSIC_USER_TOKEN=${token}`;
+  if (/^#?\s*APPLE_MUSIC_USER_TOKEN=.*$/m.test(env)) {
+    env = env.replace(/^#?\s*APPLE_MUSIC_USER_TOKEN=.*$/m, line);
+  } else {
+    env = env.replace(/\s*$/, "") + "\n" + line + "\n";
+  }
+  writeFileSync(ENV_PATH, env);
+  console.log("✅ Saved APPLE_MUSIC_USER_TOKEN to server/.env");
+  res.json({ ok: true });
+});
+
+app.get("/", (req, res) => {
+  const page = readFileSync(join(__dirname, "..", "apple-auth.html"), "utf8")
+    // Point MusicKit JS at this capture server's dev-token route, and POST the
+    // captured token back to /save so it lands in .env automatically.
+    .replace(
+      "out.textContent = \"APPLE_MUSIC_USER_TOKEN=\" + userToken;",
+      `out.textContent = "APPLE_MUSIC_USER_TOKEN=" + userToken;
+          fetch("/save", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ token: userToken }) })
+            .then(() => { out.textContent += "\\n\\n✓ Saved to server/.env"; });`
+    );
+  res.type("html").send(page);
+});
+
+app.listen(PORT, "127.0.0.1", () => {
+  console.log(`🎟️  Apple Music token capture: http://localhost:${PORT}/`);
+});

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,19 @@ import * as dotenv from "dotenv";
 import express from "express";
 import { createServer } from "http";
 import { WebSocket, WebSocketServer } from "ws";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import {
+  getDeveloperToken,
+  getRecentTracks,
+  appleTrackToRecord,
+  resolveArtistId,
+  isAppleMusicConfigured,
+} from "./appleMusic.js";
+
+// ESM equivalent of __dirname, used to serve the Apple auth page.
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Server Architecture Overview:
@@ -70,6 +83,11 @@ const HOST = process.env.HOST || "localhost";
 const PORT = process.env.PORT || 3000;
 const MONGODB_URI = process.env.MONGODB_URI;
 const DB_NAME = "personal_data";
+
+// "On Repeat" rolling window — top artist is computed over the last N days.
+const ON_REPEAT_WINDOW_DAYS = 3;
+// How often the server polls Apple Music for new plays.
+const APPLE_POLL_INTERVAL_MS = 15 * 60 * 1000;
 
 /**
  * MongoDB Connection
@@ -517,30 +535,29 @@ async function getListeningStatsHandler(req, res) {
 }
 
 /**
- * Route Handler: Get Top Artist in Last 60 Days
+ * Route Handler: Get Top Artist ("On Repeat")
  * -------------------------------------------
  * GET /api/listening-history/top-artist
  *
- * Returns the most listened to artist in the last 60 days
- * Includes sample track data to get Apple Music metadata
+ * Returns the most-played artist over a rolling window (ON_REPEAT_WINDOW_DAYS),
+ * aggregated from listening_history. The window is kept current autonomously by
+ * the Apple Music poller (pollApplePlaysIntoMongo) — no phone app required.
  */
 async function getTopArtistHandler(req, res) {
   try {
     const listeningHistory = client.db(DB_NAME).collection("listening_history");
 
-    // Get date 60 days ago
-    const sixtyDaysAgo = new Date();
-    sixtyDaysAgo.setDate(sixtyDaysAgo.getDate() - 60);
+    const windowStart = new Date();
+    windowStart.setDate(windowStart.getDate() - ON_REPEAT_WINDOW_DAYS);
 
-    // Top artist in last 60 days with sample track for metadata
     const topArtist = await listeningHistory
       .aggregate([
-        { $match: { timestamp: { $gte: sixtyDaysAgo } } },
+        { $match: { timestamp: { $gte: windowStart } } },
         {
           $group: {
             _id: "$artist_name",
             count: { $sum: 1 },
-            // Get the most recent track from this artist for metadata
+            // Most recent track from this artist, for metadata/deep links.
             sample_track: { $first: "$$ROOT" },
           },
         },
@@ -550,22 +567,35 @@ async function getTopArtistHandler(req, res) {
       .toArray();
 
     if (!topArtist.length) {
-      return res.status(404).json({ message: "No listening history in the last 60 days" });
+      return res.status(404).json({
+        message: `No listening history in the last ${ON_REPEAT_WINDOW_DAYS} days`,
+      });
     }
 
+    const sample = topArtist[0].sample_track || {};
     const result = {
       artist_name: topArtist[0]._id,
       play_count: topArtist[0].count,
+      window_days: ON_REPEAT_WINDOW_DAYS,
     };
 
-    // Add Apple Music Artist ID if available
-    if (topArtist[0].sample_track?.apple_music_artist_id) {
-      result.apple_music_artist_id = topArtist[0].sample_track.apple_music_artist_id;
+    if (sample.apple_music_artist_id) {
+      result.apple_music_artist_id = sample.apple_music_artist_id;
+    }
+    if (sample.spotify_uri) result.spotify_uri = sample.spotify_uri;
+    if (sample.album_artwork_url) {
+      result.album_artwork_url = sample.album_artwork_url;
     }
 
-    // Add Spotify URI if available
-    if (topArtist[0].sample_track?.spotify_uri) {
-      result.spotify_uri = topArtist[0].sample_track.spotify_uri;
+    // Resolve a catalog artist ID for a proper Apple Music deep link when one
+    // wasn't stored. Non-fatal — the UI falls back to an artist search.
+    if (!result.apple_music_artist_id && isAppleMusicConfigured()) {
+      try {
+        const id = await resolveArtistId(result.artist_name);
+        if (id) result.apple_music_artist_id = id;
+      } catch {
+        /* ignore */
+      }
     }
 
     res.json(result);
@@ -579,6 +609,157 @@ async function getTopArtistHandler(req, res) {
   }
 }
 
+/**
+ * Route Handler: Apple Music Developer Token
+ * ------------------------------------------
+ * GET /api/apple-music/dev-token
+ *
+ * Returns the short-lived ES256 developer token for MusicKit JS to use on the
+ * one-time auth page. This token is safe to expose to the browser — it is not
+ * the private key and grants no library access without a Music User Token.
+ */
+async function appleMusicDevTokenHandler(req, res) {
+  if (!isAppleMusicConfigured() && !process.env.APPLE_MUSIC_KEY_ID) {
+    return res
+      .status(503)
+      .json({ error: "Apple Music developer token not configured" });
+  }
+  try {
+    const token = await getDeveloperToken();
+    res.json({ token });
+  } catch (error) {
+    console.error("❌ Error minting developer token:", error.message);
+    res.status(500).json({ error: "Failed to mint developer token" });
+  }
+}
+
+/**
+ * Route Handler: Apple Music Recent Tracks (debug/verification)
+ * ------------------------------------------------------------
+ * GET /api/apple-music/recent
+ *
+ * Returns the raw recently played tracks from Apple Music. Useful to confirm
+ * the Music User Token works end to end after setup.
+ */
+async function appleMusicRecentHandler(req, res) {
+  if (!isAppleMusicConfigured()) {
+    return res.status(503).json({ error: "Apple Music not configured" });
+  }
+  try {
+    const items = await getRecentTracks(30);
+    res.json({
+      count: items.length,
+      tracks: items.map((i) => ({
+        name: i?.attributes?.name,
+        artist: i?.attributes?.artistName,
+        album: i?.attributes?.albumName,
+      })),
+    });
+  } catch (error) {
+    console.error("❌ Error fetching Apple Music recent tracks:", error.message);
+    res.status(502).json({ error: error.message });
+  }
+}
+
+/**
+ * Route Handler: Apple Music Auth Page
+ * ------------------------------------
+ * GET /apple-auth
+ *
+ * Serves the one-time MusicKit JS page used to capture the Music User Token.
+ */
+function appleAuthPageHandler(req, res) {
+  try {
+    const html = readFileSync(join(__dirname, "apple-auth.html"), "utf8");
+    res.type("html").send(html);
+  } catch (error) {
+    console.error("❌ Error serving apple-auth page:", error.message);
+    res.status(500).send("Auth page unavailable");
+  }
+}
+
+/**
+ * Apple Music Poller
+ * ------------------
+ * Fetches recently played tracks from Apple Music and persists any NEW plays
+ * into listening_history with an approximate (poll-time) timestamp, so the
+ * "On Repeat" window stays current without the iOS app.
+ *
+ * New plays are detected by diffing the current track IDs against the previous
+ * poll's IDs (stored in apple_music_state). This avoids the re-flood/over-count
+ * bug that corrupted the old phone-app data — a track is only recorded the first
+ * poll it appears in, or again if it leaves and re-enters the recent window.
+ */
+let applePollInFlight = false;
+
+async function pollApplePlaysIntoMongo() {
+  if (!isAppleMusicConfigured()) return { skipped: "not configured" };
+  if (applePollInFlight) return { skipped: "already running" };
+  applePollInFlight = true;
+  try {
+    const db = client.db(DB_NAME);
+    const history = db.collection("listening_history");
+    const state = db.collection("apple_music_state");
+
+    const items = await getRecentTracks(30);
+    if (!items.length) return { inserted: 0, reason: "no recent tracks" };
+
+    const currentIds = items.map((i) => i?.id).filter(Boolean);
+    const stateDoc = await state.findOne({ _id: "recent_tracks" });
+    const firstRun = !stateDoc;
+    const prevIds = new Set(stateDoc?.last_ids || []);
+
+    // First run seeds the window; later runs record only newly appeared tracks.
+    const newItems = firstRun
+      ? items
+      : items.filter((i) => i?.id && !prevIds.has(i.id));
+
+    const playedAt = new Date();
+    let inserted = 0;
+    if (newItems.length) {
+      const records = newItems.map((item, idx) => ({
+        // Stagger timestamps (most-recent first) so play ordering is stable.
+        ...appleTrackToRecord(
+          item,
+          new Date(playedAt.getTime() - idx * 1000)
+        ),
+        created_at: new Date(),
+        updated_at: new Date(),
+      }));
+      const result = await history.insertMany(records, { ordered: false });
+      inserted = result.insertedCount;
+      broadcastNewTrack(records[0]); // newest play -> live clients
+    }
+
+    await state.updateOne(
+      { _id: "recent_tracks" },
+      { $set: { last_ids: currentIds, updated_at: new Date() } },
+      { upsert: true }
+    );
+
+    if (inserted) console.log(`🎧 Apple poll: +${inserted} new play(s)`);
+    return { inserted, firstRun, seen: currentIds.length };
+  } catch (error) {
+    console.error("❌ Apple poll failed:", error.message);
+    return { error: error.message };
+  } finally {
+    applePollInFlight = false;
+  }
+}
+
+/**
+ * Route Handler: Trigger Apple Poll (manual)
+ * ------------------------------------------
+ * GET /api/apple-music/poll — handy right after deploy to seed the window.
+ */
+async function appleMusicPollHandler(req, res) {
+  if (!isAppleMusicConfigured()) {
+    return res.status(503).json({ error: "Apple Music not configured" });
+  }
+  const result = await pollApplePlaysIntoMongo();
+  res.json(result);
+}
+
 // Route definitions
 app.post("/api/workouts", createWorkoutHandler);
 app.get("/api/workouts", getWorkoutsHandler);
@@ -586,6 +767,12 @@ app.post("/api/listening-history", createListeningHistoryHandler);
 app.get("/api/listening-history", getListeningHistoryHandler);
 app.get("/api/listening-history/stats", getListeningStatsHandler);
 app.get("/api/listening-history/top-artist", getTopArtistHandler);
+
+// Apple Music integration (autonomous server-side polling)
+app.get("/api/apple-music/dev-token", appleMusicDevTokenHandler);
+app.get("/api/apple-music/recent", appleMusicRecentHandler);
+app.get("/api/apple-music/poll", appleMusicPollHandler);
+app.get("/apple-auth", appleAuthPageHandler);
 
 /**
  * Graceful Shutdown Handler
@@ -620,6 +807,18 @@ async function startServer() {
       console.log(`📱 Network access: http://192.168.0.118:${PORT}`);
       console.log(`🔌 WebSocket server is running`);
       console.log(`📅 Server started at: ${new Date().toISOString()}`);
+
+      // Autonomous Apple Music polling keeps the "On Repeat" window fresh.
+      if (isAppleMusicConfigured()) {
+        pollApplePlaysIntoMongo();
+        setInterval(pollApplePlaysIntoMongo, APPLE_POLL_INTERVAL_MS);
+        console.log(
+          `🎧 Apple Music polling every ${APPLE_POLL_INTERVAL_MS / 60000} min ` +
+            `(On Repeat window: ${ON_REPEAT_WINDOW_DAYS} days)`
+        );
+      } else {
+        console.log("ℹ️ Apple Music not configured — polling disabled");
+      }
     });
   } catch (error) {
     console.error("❌ Failed to start server:", error);


### PR DESCRIPTION
## What & why

The navbar **"On Repeat"** widget moved from Spotify → Apple Music via a phone app (`nvmMusic`) that had to be opened manually to sync, and produced wrong "top" artists due to a re-flood/over-count bug. This makes it **fully autonomous** — the server reads Apple Music directly and keeps a rolling **3-day** top artist current, no phone required.

## How it works

- **Developer token** — `appleMusic.js` signs an ES256 JWT (`jose`) from the MusicKit `.p8` key.
- **User token** — captured once via MusicKit JS (`/apple-auth` + `scripts/captureAppleUserToken.js`), stored as an env var.
- **Poller** — every 15 min the server fetches `/me/recent/played/tracks` and upserts only *new* plays into `listening_history`, diffing against the previous poll's track IDs (no more over-counting).
- **`/top-artist`** — aggregates `listening_history` over a rolling 3-day window; resolves a catalog artist ID for a proper Apple Music deep link.
- **Graceful fallback** — if the Apple token is missing/expired, the endpoint still serves stored history, so the widget never errors.

Backend-only — the Vercel frontend already calls the Railway `/top-artist` URL, so no frontend change.

## Verification (done locally against a throwaway Mongo + real Apple account)

- ✅ Apple accepts the signed developer token (live catalog call)
- ✅ Startup poll seeded 30 plays; `/top-artist` → **Flume (17), 3-day window**, with artwork + artist ID `4275634`
- ✅ Re-poll with no change → **+0 inserted** (dedup works)
- ✅ Simulated 3 rotated-in tracks → **+3 inserted** (new-play path works)

## Deploy steps (after merge)

Railway auto-deploys `main`. Set these 4 variables in Railway first (the two secrets are in local `server/.env`):

| Variable | Value |
|---|---|
| `APPLE_TEAM_ID` | `HST68XV9V5` |
| `APPLE_MUSIC_KEY_ID` | `X242QF7RAL` |
| `APPLE_MUSIC_PRIVATE_KEY` | (base64 from `server/.env`) |
| `APPLE_MUSIC_USER_TOKEN` | (from `server/.env`) |

Then verify: `GET /api/apple-music/poll` (seeds the window) and `GET /api/listening-history/top-artist`.

## Notes
- The `nvmMusic` iOS app is now obsolete and can be retired.
- `Spotify.jsx` is dead code (unmounted) — left as-is; can remove in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)