### PR TITLE
Reframe Hue U card around the engineering

### DIFF
--- a/client/src/components/body/ProjectsShowcase.jsx
+++ b/client/src/components/body/ProjectsShowcase.jsx
@@ -178,6 +178,14 @@ const ProjectCardDetails = ({ project, colorScheme, accentColor }) => (
             <span>Website</span>
           </a>
         )}
+        {project.linkList.ios === "coming-soon" && (
+          <span
+            className={`flex items-center space-x-1.5 px-3 py-1.5 rounded-md text-xs font-medium opacity-70 cursor-default ${colorScheme.techPill}`}
+          >
+            <MyIcon icon="fa-brands fa-apple" size="text-xs" />
+            <span>iOS Coming Soon</span>
+          </span>
+        )}
       </div>
     )}
   </div>

--- a/client/src/projects/hue-u.md
+++ b/client/src/projects/hue-u.md
@@ -1,12 +1,12 @@
-# Hue U, AI-Powered Coloring Book Platform
+# Hue U, AI Commerce Platform
 
 ## Description
 
-Full-stack platform that transforms photos into coloring pages using AI, with a book builder and print-on-demand ordering. Built independently from idea through production, handling backend, web app, payments, and print fulfillment.
+A multi-platform business (web app and native iOS) that turns photos into custom coloring books with print-on-demand fulfillment. Built and run solo, end to end. The coloring books are the product; the harder part is the system behind them: an AI generation pipeline, real payment and fulfillment flows, and an agent-driven layer that helps build and operate the business.
 
 ## Status
 
-Personal Project
+Launching Soon
 
 ## Type
 
@@ -17,17 +17,23 @@ project
 - Python
 - FastAPI
 - Next.js
+- SwiftUI
 - Supabase
-- Google Gemini
 - Stripe
+- TypeScript
+- MCP
+- OpenRouter
 - Docker
 - Google Cloud
+- DigitalOcean
 
 ## Features
 
-- AI-powered photo-to-line-art generation
-- Book builder with print-on-demand fulfillment
-- Credit system with Stripe payment integration
+- AI generation pipeline with per-image prompting and a scored quality eval harness
+- Native iOS app (SwiftUI, GPU-accelerated canvas) alongside a Next.js web builder
+- Hermes, an always-on ops agent that reads the live business and runs approval-gated actions behind a strict read/write trust boundary
+- Stripe payments, credit system, and automated print-on-demand fulfillment
+- Production hardening: JWT platform attestation, audited writes, and secrets pulled at runtime
 
 ## Role
 
@@ -36,6 +42,7 @@ Founder
 ## Links
 
 - **Website**: https://hueu.ai
+- **iOS**: coming-soon
 
 ## Icon
 


### PR DESCRIPTION
## Summary
Repositions the Hue U entry on the Projects section to convey the tech behind it rather than just the coloring-book product, ahead of its launch.

- Title now reads **Hue U, AI Commerce Platform**; status changed to **Launching Soon**
- Description and features lead with the engineering: full-stack (web + native iOS), AI generation pipeline with eval harness, Hermes agent ops layer, Stripe + print-on-demand, production hardening
- Tech stack expanded: adds SwiftUI, TypeScript, MCP, OpenRouter, DigitalOcean
- Adds a non-clickable **iOS Coming Soon** badge with the Apple icon, rendered when a project's link entry is `coming-soon` (reusable, not hardcoded to Hue U)

## Testing
Verified locally in the browser: card renders correctly, the iOS badge shows the Apple glyph as a muted non-clickable pill next to the Website button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)