### PR TITLE
Fix mobile checkmark bullet alignment

### DIFF
--- a/client/src/components/body/ProjectsShowcase.jsx
+++ b/client/src/components/body/ProjectsShowcase.jsx
@@ -87,10 +87,10 @@ const ProjectCardDetails = ({ project, colorScheme, accentColor }) => (
         </h4>
         <ul className={`text-sm ${colorScheme.text} space-y-1`}>
           {project.featureList.map((feature, i) => (
-            <li key={i} className="flex items-center">
+            <li key={i} className="flex items-start">
               <FontAwesomeIcon
                 icon={faCheck}
-                className="text-xs mr-2 shrink-0"
+                className="text-xs mr-2 mt-1 shrink-0"
                 style={{ color: accentColor }}
               />
               {feature}

--- a/client/src/components/body/WorkExperienceShowcase.jsx
+++ b/client/src/components/body/WorkExperienceShowcase.jsx
@@ -104,10 +104,10 @@ const ExperienceCard = ({ experience, index }) => {
             </h4>
             <ul className={`text-sm ${colorScheme.text} space-y-1`}>
               {experience.featureList.map((feature, i) => (
-                <li key={i} className="flex items-center">
+                <li key={i} className="flex items-start">
                   <FontAwesomeIcon
                     icon={faCheck}
-                    className="text-xs mr-2"
+                    className="text-xs mr-2 mt-1 shrink-0"
                     style={{ color: accentColor }}
                   />
                   {feature}


### PR DESCRIPTION
## Summary
- Checkmark bullets in the Key Responsibilities/Features lists used `items-center`, which vertically centered the icon against the whole wrapped `<li>` block instead of the first line of text — looked misaligned on mobile where lines wrap.
- Switched to `items-start` with a small top margin on the icon so it stays flush with the first line, in both `WorkExperienceShowcase.jsx` and `ProjectsShowcase.jsx`.

## Test plan
- [ ] Vercel preview deploy — check the work experience and project cards on mobile width, confirm checkmarks line up with the top line of wrapped text

---
_Created by claude-sonnet-4-6_